### PR TITLE
Add IPOption_RFC3692_style_experiment class [resolves #16]

### DIFF
--- a/mca/forge.py
+++ b/mca/forge.py
@@ -48,7 +48,7 @@ class Forge:
         ip_packet = scapy.all.IP(src=self.src_ip, dst=dst, ttl=self.probe.ttl, tos=tos)
 
         if self.extended_classification_flow_id_index is not None:
-                ip_rfc3692_style_experiment_option = IPOption_RFC3692_style_experiment(value=high_entropy_flow_ids[self.extended_classification_flow_id_index])
+            ip_rfc3692_style_experiment_option = IPOption_RFC3692_style_experiment(value=high_entropy_flow_ids[self.extended_classification_flow_id_index])
             ip_packet.options.append(ip_rfc3692_style_experiment_option)
 
         self.packet /= ip_packet

--- a/mca/forge.py
+++ b/mca/forge.py
@@ -6,6 +6,7 @@ import scapy.all
 from typing import Optional
 
 from mca.flow_ids import high_entropy_flow_ids
+from mca.scapyextensions import IPOption_RFC3692_style_experiment
 
 
 class Forge:
@@ -47,12 +48,8 @@ class Forge:
         ip_packet = scapy.all.IP(src=self.src_ip, dst=dst, ttl=self.probe.ttl, tos=tos)
 
         if self.extended_classification_flow_id_index is not None:
-            ip_option = scapy.all.IPOption(copy_flag = 0, # Don't copy into all fragments of fragmentation
-                                            optclass = 2, # Case 2 format of option
-                                            option = 30, # RFC3692-style Experiment
-                                            length = 16, # 16 bits
-                                            value = high_entropy_flow_ids[self.extended_classification_flow_id_index])
-            ip_packet.options.append(ip_option)
+                ip_rfc3692_style_experiment_option = IPOption_RFC3692_style_experiment(value=high_entropy_flow_ids[self.extended_classification_flow_id_index])
+            ip_packet.options.append(ip_rfc3692_style_experiment_option)
 
         self.packet /= ip_packet
 

--- a/mca/scapyextensions.py
+++ b/mca/scapyextensions.py
@@ -1,0 +1,12 @@
+import scapy.all
+from scapy.layers.inet import _IPOption_HDR
+
+class IPOption_RFC3692_style_experiment(scapy.all.IPOption):
+    name = "RFC3692-style experiment"
+    copy_flag = 0
+    optclass = 2
+    option = 30
+    fields_desc = [_IPOption_HDR,
+                   scapy.all.ByteField("length", 4),
+                   scapy.all.ShortField("value", 0)
+                  ]


### PR DESCRIPTION
Adding the `IPOption_RFC3692_style_experiment` subclass to be used during the IPv4 extended classification and wiring it up on `forge.py`. @cunha these changes have been discussed during our 5/2/2021 meeting.