### PR TITLE
Script for testing extended classification packets [resolves #18]

### DIFF
--- a/packet_testing/extclass_packet_testing.py
+++ b/packet_testing/extclass_packet_testing.py
@@ -5,13 +5,6 @@ from scapy.layers.inet import _IPOption_HDR
 from scapy.layers import inet6
 
 
-parser = argparse.ArgumentParser(description='Tests the packets used during the MCA extended classification step.')
-parser.add_argument('-d', '--destination_ip', required=True,
-                    help='The destination IP address for testing the packets.')
-parser.add_argument('-s', '--send_packets', action='store_true',
-                    help='Send the experiment packets.')
-
-
 class IPOption_RFC3692_style_experiment(scapy.all.IPOption):
     name = "RFC3692-style experiment"
     copy_flag = 0
@@ -89,5 +82,12 @@ class ExtClassExperiment:
                 scapy.all.sendp(tcp_packet)
                 scapy.all.sendp(icmp_packet)
 
-args = parser.parse_args()
-ExtClassExperiment(args.destination_ip, args.send_packets).run()
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Tests the packets used during the MCA extended classification step.')
+    parser.add_argument('-d', '--destination_ip', required=True,
+                        help='The destination IP address to test.')
+    parser.add_argument('-s', '--send_packets', action='store_true',
+                        help='Send the experiment packets.')
+
+    args = parser.parse_args()
+    ExtClassExperiment(args.destination_ip, args.send_packets).run()

--- a/packet_testing/extclass_packet_testing.py
+++ b/packet_testing/extclass_packet_testing.py
@@ -1,0 +1,93 @@
+import argparse
+import ipaddress
+import scapy.all
+from scapy.layers.inet import _IPOption_HDR
+from scapy.layers import inet6
+
+
+parser = argparse.ArgumentParser(description='Tests the packets used during the MCA extended classification step.')
+parser.add_argument('-d', '--destination_ip', required=True,
+                    help='The destination IP address for testing the packets.')
+parser.add_argument('-s', '--send_packets', action='store_true',
+                    help='Send the experiment packets.')
+
+
+class IPOption_RFC3692_style_experiment(scapy.all.IPOption):
+    name = "RFC3692-style experiment"
+    copy_flag = 0
+    optclass = 2
+    option = 30
+    fields_desc = [_IPOption_HDR,
+                   scapy.all.ByteField("length", 4),
+                   scapy.all.ShortField("value", 0)
+                  ]
+
+class IPv6ExtHdrRFC3692_style_experiment(inet6._IPv6ExtHdr):
+    name = "IPv6 Extension Header - RFC3692-style experiment Header"
+    fields_desc = [scapy.all.ByteEnumField("nh", 59, scapy.all.ipv6nh),
+                   scapy.all.ByteField("length", 0),
+                   scapy.all.ShortField("value", 0),
+                   scapy.all.ShortField("padding1", 0),
+                   scapy.all.ShortField("padding2", 0)
+                  ]
+    overload_fields = {scapy.all.IPv6: {"nh": 253}}
+
+
+# Ading the RFC3692 class to the ipv6nhcls dict
+inet6.ipv6nhcls[253] = IPv6ExtHdrRFC3692_style_experiment
+
+
+class ExtClassExperiment:
+    def __init__(self, destination_ip: str, send_packets: bool) -> None:
+        self.__destination_ip = destination_ip
+        self.__send_packets = send_packets
+
+        self.__ip_version = ipaddress.ip_address(args.destination_ip).version
+
+        if self.__ip_version == 4:
+            _, self.__source_ip, _ = scapy.all.conf.route.route(args.destination_ip)
+        elif self.__ip_version == 6:
+            _, self.__source_ip, _ = scapy.all.conf.route6.route(args.destination_ip)
+
+        self.__payload = 'http://www.dcc.ufmg.br/~cunha/hosted/ipv6-exthdr-balancing'
+
+    def run(self):
+        if self.__ip_version == 4:
+            dest_ip = str(ipaddress.IPv4Address(self.__destination_ip))
+
+            # IP packet to be used for udp, tcp and icmp
+            ip_packet = scapy.all.IP(src=self.__source_ip, dst=dest_ip)
+            ip_packet.options.append(IPOption_RFC3692_style_experiment(value=56059))
+
+            udp_packet = scapy.all.Ether() / ip_packet / scapy.all.UDP() / self.__payload
+            tcp_packet = scapy.all.Ether() / ip_packet / scapy.all.TCP() / self.__payload
+            icmp_packet = scapy.all.Ether() / ip_packet / scapy.all.ICMP() / self.__payload
+
+            if self.__send_packets:
+                scapy.all.sendp(udp_packet)
+                scapy.all.sendp(tcp_packet)
+                scapy.all.sendp(icmp_packet)
+
+        elif self.__ip_version == 6:
+            dest_ip = str(ipaddress.IPv6Address(self.__destination_ip))
+
+            ipv6_packet = scapy.all.IPv6(src=self.__source_ip, dst=dest_ip)
+
+            # packet using the fragment header
+            fragment_packet = scapy.all.Ether() / ipv6_packet / scapy.all.IPv6ExtHdrFragment(offset=56059)
+
+            # Packets using RFC3692 - UDP, TCP, ICMP
+            ipv6_rfc3692_header = IPv6ExtHdrRFC3692_style_experiment(value=56059)
+
+            udp_packet = scapy.all.Ether() / ipv6_packet / ipv6_rfc3692_header / scapy.all.UDP() / self.__payload
+            tcp_packet = scapy.all.Ether() / ipv6_packet / ipv6_rfc3692_header / scapy.all.TCP() / self.__payload
+            icmp_packet = scapy.all.Ether() / ipv6_packet / ipv6_rfc3692_header / scapy.all.ICMPv6EchoRequest() / self.__payload
+
+            if self.__send_packets:
+                scapy.all.sendp(fragment_packet)
+                scapy.all.sendp(udp_packet)
+                scapy.all.sendp(tcp_packet)
+                scapy.all.sendp(icmp_packet)
+
+args = parser.parse_args()
+ExtClassExperiment(args.destination_ip, args.send_packets).run()


### PR DESCRIPTION
This is an initial version of the script for testing the packets that will be used during the extended classification step. The experiment behaves differently based on whether the destination used for the experiment is an IPv4 or an IPv6 address.

When using an IPv4 destination address, three different packets are tested. All of them are based on the same IPv4 packet/RFC3692 option, the only difference being in the transport layer:

1. UDP header;
2. TCP header;
3. ICMP header.


When using an IPv6 destination address, four different packets are tested. Three of them are based on the same IPv4 packet/RFC3692 option, the only difference being in the transport layer. 

1. UDP header;
2. TCP header;
3. ICMPv6 header.

The IPv6 fourth packet uses the Fragmentation Extension Header, and the transport layer is kept undefined.

The output of `show()`, `show2()` and the hex raw packet will be shown for all the 3 IPv4 and 4 IPV6 packets.

1. IPv4/UDP
   - `show()` output:
      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118591476-99410380-b77a-11eb-9667-f0812b619ea2.png">
      </div>

   - `show2()` output:
      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118591881-5e8b9b00-b77b-11eb-8b73-8a81fbd21175.png">
      </div>

   - raw packet:
      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118592446-554efe00-b77c-11eb-8e10-fcada5a046da.png">
      </div>

2. IPv4/TCP
   - `show()` output:
      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118592121-d2c63e80-b77b-11eb-8345-4ee53d99dae8.png">
      </div>

   - `show2()` output:
      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118592247-0f923580-b77c-11eb-8ea1-c511d6cf6cdf.png">
      </div>

   - raw packet:

      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118592333-2afd4080-b77c-11eb-9efa-780ba4ffbdd4.png">
      </div>

3. IPv4/ICMP

   - `show()` output:

      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118592636-a2cb6b00-b77c-11eb-9992-8f038033f0a5.png">
      </div>

   - `show2()` output:

      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118592676-b971c200-b77c-11eb-9b2e-eaa00cb61b97.png">
      </div>

   - raw packet:

      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118592717-cb536500-b77c-11eb-8468-ff3423eb9ea4.png">
      </div>


4. IPv6/UDP

   - `show()` output:

      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118592935-3866fa80-b77d-11eb-896a-171b1e7a6e67.png">
      </div>

   - `show2()` output:

      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118592972-4ae13400-b77d-11eb-8849-0fdfb9ee1629.png">
      </div>

   - raw packet:

      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118592995-59c7e680-b77d-11eb-9dad-dc3c18c3a681.png">
      </div>

5. IPv6/TCP

   - `show()` output:

      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118593893-dad3ad80-b77e-11eb-8fcd-df34618a05a4.png">
      </div>

   - `show2()` output:

      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118593938-f2129b00-b77e-11eb-8adb-0c5a30152c63.png">
      </div>

   - raw packet:

      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118593971-00f94d80-b77f-11eb-9f00-684282cc358c.png">
      </div>

6. IPv6/ICMPv6

   - `show()` output:

      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118594102-39992700-b77f-11eb-825b-2067e9bca471.png">
      </div>

   - `show2()` output:

      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118594152-503f7e00-b77f-11eb-86e2-cdaf8541bb18.png">
      </div>

   - raw packet:

      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118594196-62212100-b77f-11eb-8332-25db4612c46c.png">
      </div>

7. IPv6/Fragmentation Header

   - `show()` output:

      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118594321-a3b1cc00-b77f-11eb-8ba2-87adb76c509f.png">
      </div>

   - `show2()` output:

      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118594351-b1ffe800-b77f-11eb-869d-a7d71741142b.png">
      </div>

   - raw packet:

      <div align="center">
      <img width="600" src="https://user-images.githubusercontent.com/16518970/118594377-c04e0400-b77f-11eb-8d64-8bd15d2f3ab9.png">
      </div>
