### PR TITLE
Add IPv6 RFC3692-style experiment class [resolves #21]

### DIFF
--- a/mca/forge.py
+++ b/mca/forge.py
@@ -6,7 +6,7 @@ import scapy.all
 from typing import Optional
 
 from mca.flow_ids import high_entropy_flow_ids
-from mca.scapyextensions import IPOption_RFC3692_style_experiment
+from mca.scapyextensions import IPOption_RFC3692_style_experiment, IPv6ExtHdrRFC3692_style_experiment
 
 
 class Forge:
@@ -65,8 +65,8 @@ class Forge:
         ipv6_packet = scapy.all.IPv6(src=self.src_ip, dst=dst, hlim=self.probe.ttl, tc=tc, fl=fl)
 
         # Placeholder for the Extended classification step
-        #if self.extended_classification_flow_id_index is not None:
-        #    ipv6_packet /= scapy.all.IPv6ExtHdrFragment(offset=high_entropy_flow_ids[self.extended_classification_flow_id_index])
+        if self.extended_classification_flow_id_index is not None:
+            ipv6_packet /= IPv6ExtHdrRFC3692_style_experiment(value=high_entropy_flow_ids[self.extended_classification_flow_id_index])
 
         self.packet /= ipv6_packet
 

--- a/mca/scapyextensions.py
+++ b/mca/scapyextensions.py
@@ -1,5 +1,6 @@
 import scapy.all
 from scapy.layers.inet import _IPOption_HDR
+from scapy.layers import inet6
 
 class IPOption_RFC3692_style_experiment(scapy.all.IPOption):
     name = "RFC3692-style experiment"
@@ -10,3 +11,18 @@ class IPOption_RFC3692_style_experiment(scapy.all.IPOption):
                    scapy.all.ByteField("length", 4),
                    scapy.all.ShortField("value", 0)
                   ]
+
+
+class IPv6ExtHdrRFC3692_style_experiment(inet6._IPv6ExtHdr):
+    name = "IPv6 Extension Header - RFC3692-style experiment Header"
+    fields_desc = [scapy.all.ByteEnumField("nh", 59, scapy.all.ipv6nh),
+                   scapy.all.ByteField("length", 0),
+                   scapy.all.ShortField("value", 0),
+                   scapy.all.ShortField("padding1", 0),
+                   scapy.all.ShortField("padding2", 0)
+                  ]
+    overload_fields = {scapy.all.IPv6: {"nh": 253}}
+
+
+# Ading the RFC3692 class to the ipv6nhcls dict
+inet6.ipv6nhcls[253] = IPv6ExtHdrRFC3692_style_experiment


### PR DESCRIPTION
Added the `IPv6ExtHdrRFC3692_style_experiment` class to the `scapyextensions` module. It leverages the `_IPv6ExtHdr` base class. Also wired it up to be used during the extended classification step/`forge` module.

The extension header was implemented using 8 octets:
- Next header (1 byte), value 59 (no next header, gets overwritten when upper layer header is attached, say TCP/UDP etc);
- Header length (1 byte), value 0 (which means just the first 8 octets);
- Value (2 bytes), value should vary according to the high-entropy values used during the extended classification step;
- Padding (4 bytes), thus completing the 8 octets.

@cunha I'm still unsure about the header length, I could not find a reference/explanation on the RFCs to reach the conclusion that a generic extension header should have the length field (although it wouldn't make a lot of sense without it).

Tested the MCA with default arguments using `8.8.4.4` as the destination. At first I thought something was broken since the destination IPs pointed out by the MCA run were intermittently either `142.251.61.235` or `142.250.238.145` (as opposed to the expected `8.8.4.4`). To make sure recent changes were not breaking MCA features I built a fresh venv with the original MCA clone. The results from a group of runs shown that the destination IPs were the same, so the behavior seems correct.
