### PR TITLE
Adding Destination Options [resolves #25]

### DIFF
--- a/mca/flow_ids.py
+++ b/mca/flow_ids.py
@@ -256,3 +256,24 @@ high_entropy_flow_ids = (
     58522, #[254]
     62720  #[255]
 )
+
+# IPv6 Destination Options PadN option data
+# to be used during extended classification
+
+# We will be varying the 4th byte
+# of the Destination Options header,
+# which is the Opt Data Len of the
+# PadN. To achieve that, we'll increment
+# Option Data by one byte each round.
+dest_opts_flow_ids = (
+    '0',
+    '00',
+    '000',
+    '0000',
+    '00000',
+    '000000',
+    '0000000',
+    '00000000',
+    '000000000',
+    '0000000000',
+)

--- a/mca/forge.py
+++ b/mca/forge.py
@@ -5,7 +5,7 @@ import sys
 import scapy.all
 from typing import Optional
 
-from mca.flow_ids import high_entropy_flow_ids
+from mca.flow_ids import dest_opts_flow_ids
 from mca.scapyextensions import IPOption_RFC3692_style_experiment, IPv6ExtHdrRFC3692_style_experiment
 
 
@@ -66,7 +66,7 @@ class Forge:
 
         # Placeholder for the Extended classification step
         if self.extended_classification_flow_id_index is not None:
-            ipv6_packet /= IPv6ExtHdrRFC3692_style_experiment(value=high_entropy_flow_ids[self.extended_classification_flow_id_index])
+            ipv6_packet /= scapy.all.IPv6ExtHdrDestOpt(options=scapy.all.PadN(optdata=dest_opts_flow_ids[self.extended_classification_flow_id_index]))
 
         self.packet /= ipv6_packet
 


### PR DESCRIPTION
This changeset is replacing the IPv6 RFC3692-style experiment header with Destination Options for extended classification as discussed with @cunha.